### PR TITLE
Fix forth24 H!

### DIFF
--- a/forth24/kernl24a.4th
+++ b/forth24/kernl24a.4th
@@ -1044,6 +1044,7 @@ END-CODE
 CODE H! ( x a-addr ---)
 \G store 16-bit value x at a-addr
     EX DE, HL
+    POP DE
     LD (HL), E
     INC HL
     LD (HL), D


### PR DESCRIPTION
H! was broken because it didn't pop the address after reading it to HL, so it wrote the address as the value and left the value on the stack.