### PR TITLE
Improved output of DUMP

### DIFF
--- a/forth16/extend80.4th
+++ b/forth16/extend80.4th
@@ -261,6 +261,7 @@ VARIABLE SOURCE-LINK
   16 0 DO
    DUP I + C@ 0 <# # # #> TYPE
   LOOP
+  SPACE
   16 0 DO
    DUP I + C@ DUP 32 < OVER 127 = OR IF DROP ." ." ELSE EMIT THEN
   LOOP
@@ -271,7 +272,7 @@ VARIABLE SOURCE-LINK
 \G Show a hex/ascii dump of the memory block of len bytes at addr
   7 + 4 RSHIFT 0 DO
    DL ?TERMINAL IF LEAVE THEN
-  LOOP DROP ;
+  LOOP DROP CR ;
 
 : H. ( u ----)
     BASE @ >R HEX U. R> BASE ! ;

--- a/forth24/extend24.4th
+++ b/forth24/extend24.4th
@@ -228,6 +228,7 @@ CONSTANT ROOT-WORDLIST ( --- wid )
   16 0 DO
    DUP I + C@ 0 <# # # #> TYPE
   LOOP
+  SPACE
   16 0 DO
    DUP I + C@ DUP 32 < OVER 127 = OR IF DROP ." ." ELSE EMIT THEN
   LOOP
@@ -238,7 +239,7 @@ CONSTANT ROOT-WORDLIST ( --- wid )
 \G Show a hex/ascii dump of the memory block of len bytes at addr
   7 + 4 RSHIFT 0 DO
    DL ?TERMINAL IF LEAVE THEN
-  LOOP DROP ;
+  LOOP DROP CR ;
 
 : H. ( u ----)
     BASE @ >R HEX U. R> BASE ! ;


### PR DESCRIPTION
I thought I'd write this simple thing to reformat the output of the DUMP command slightly. I didn't like the way the hex codes and ASCII values mashed up together.

Before:
![image](https://github.com/user-attachments/assets/c79d7fe3-945d-4d50-90f4-1fe10ede9b0e)

After:
![image](https://github.com/user-attachments/assets/5d8770c1-d071-47d7-9050-7688b41676a9)
